### PR TITLE
Group dashboard / API connection

### DIFF
--- a/client/src/actions/group.js
+++ b/client/src/actions/group.js
@@ -26,7 +26,7 @@ export const fetchGroup = () => async dispatch => {
         let { groupID } = profile.data;
 
         if (!groupID) {
-            dispatch({ type: FETCH_GROUP, payload: { _id: null } })
+            return dispatch({ type: FETCH_GROUP, payload: { _id: null } })
         }
 
         const group = await axios.get("/groups/" + groupID, config());


### PR DESCRIPTION
# NOTE BEFORE MERGE

Without removing the `checkSignature` middleware on `$API/user/profile` this doesn't work on my machine. When the only middleware check on that route is `authenticated` it works. I'm not sure if that's a config issue in my environment or not. @LuisOsta please test this PR before merging and let me know if it works without changing the API.

Also, this won't work at all without #56 and the creation flow won't work without #57.